### PR TITLE
Expose EPMD port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ RUN apt-get -qq update > /dev/null
 RUN apt-get -qq -y install rabbitmq-server > /dev/null
 RUN /usr/sbin/rabbitmq-plugins enable rabbitmq_management
 
-EXPOSE 5672 15672
+EXPOSE 5672 15672 4369
 
 CMD /usr/sbin/rabbitmq-server


### PR DESCRIPTION
Add EPMD (Erlang Port Mapper Daemon) port to the list of exposed ports. This is to allow clustering of rabbitmq servers running in different containers on different hosts.
