### PR TITLE
Enable guest account

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN echo "deb http://www.rabbitmq.com/debian/ testing main" > /etc/apt/sources.l
 RUN apt-get -qq update > /dev/null
 RUN apt-get -qq -y install rabbitmq-server > /dev/null
 RUN /usr/sbin/rabbitmq-plugins enable rabbitmq_management
+RUN echo "[{rabbit, [{loopback_users, []}]}]." > /etc/rabbitmq/rabbitmq.config
 
 EXPOSE 5672 15672 4369
 


### PR DESCRIPTION
RabbitMQ 3.3 disabled the `guest` account for non-localhost access which seems to include non default ports. This commit re-enables the `guest` account.
