### PR TITLE
explicitly specify the mapping from host (docker host) ports to container ports

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "docker" do |d|
     d.pull_images "mikaelhg/docker-rabbitmq"
     d.run "mikaelhg/docker-rabbitmq",
-      args: "-h rabbithost -p :5672 -p :15672"
+      args: "-h rabbithost -p 0.0.0.0:5672:5672 -p 0.0.0.0:15672:15672"
   end
 end


### PR DESCRIPTION
without doing this, it seems that docker auto-assigns a port which doesn't then match the ports that are opened up by vagrant on the VM
